### PR TITLE
hive: parse CREATE/DROP FUNCTION into UnhandledStatement

### DIFF
--- a/src/Database/Sql/Hive/Parser.hs
+++ b/src/Database/Sql/Hive/Parser.hs
@@ -82,6 +82,12 @@ statementParser = do
         , try $ HiveTruncatePartitionStmt <$> truncatePartitionStatementP
         , HiveUnhandledStatement <$> describeP
         , HiveUnhandledStatement <$> showP
+        , do
+              _ <- try $ P.lookAhead createFunctionPrefixP
+              HiveUnhandledStatement <$> createFunctionP
+        , do
+              _ <- try $ P.lookAhead dropFunctionPrefixP
+              HiveUnhandledStatement <$> dropFunctionP
         , HiveStandardSqlStatement <$> statementP
         , try $ HiveAlterTableSetLocationStmt <$> alterTableSetLocationP
         , try $ HiveUnhandledStatement <$> alterTableSetTblPropertiesP
@@ -364,6 +370,33 @@ showP = do
     e <- P.many1 Tok.notSemicolonP
     return $ s <> last e
 
+
+createFunctionPrefixP :: Parser Range
+createFunctionPrefixP = do
+    s <- Tok.createP
+    optional Tok.temporaryP
+    e <- Tok.functionP
+    return $ s <> e
+
+createFunctionP :: Parser Range
+createFunctionP = do
+   s <- createFunctionPrefixP
+   e <- P.many1 Tok.notSemicolonP
+   return $ s <> last e
+
+
+dropFunctionPrefixP :: Parser Range
+dropFunctionPrefixP = do
+    s <- Tok.dropP
+    optional Tok.temporaryP
+    e <- Tok.functionP
+    return $ s <> e
+
+dropFunctionP :: Parser Range
+dropFunctionP = do
+   s <- dropFunctionPrefixP
+   e <- P.many1 Tok.notSemicolonP
+   return $ s <> last e
 
 alterTableSetLocationP :: Parser (AlterTableSetLocation RawNames Range)
 alterTableSetLocationP = do

--- a/test/Database/Sql/Hive/Parser/Test.hs
+++ b/test/Database/Sql/Hive/Parser/Test.hs
@@ -445,6 +445,10 @@ testParser_hiveSuite = test
         ]
       , "ALTER TABLE foo.bar PARTITION(baz) ADD COLUMNS (quux1 int, quux2 int);"
       , "SELECT stack(4, 'a', 364, 'b', 42, 'c', 7, 'd', 1) AS (col1, col2);"
+      , "CREATE FUNCTION foo.bar AS 'class' USING JAR 'hdfs:///path';"
+      , "CREATE TEMPORARY FUNCTION foo AS 'class';"
+      , "DROP FUNCTION foo;"
+      , "DROP TEMPORARY FUNCTION foo;"
       ]
 
     , "Parse failure on malformed HiveQL statements" ~: map (TestCase . parsesUnsuccessfully)


### PR DESCRIPTION
We don't care about analyzing these queries (for now). We *do* care that
they impact our overall parse-success rate. As such, parse them
(liberally) but don't open them up for analysis.