### PR TITLE
add toJSON instances for Resolved statements

### DIFF
--- a/src/Database/Sql/Hive/Type.hs
+++ b/src/Database/Sql/Hive/Type.hs
@@ -347,6 +347,9 @@ instance (ConstrainSNames ToJSON r a, ToJSON a) => ToJSON (HiveStatement r a) wh
         , "info" .= info
         ]
 
+typeExample :: ()
+typeExample = const () $ toJSON (undefined :: HiveStatement ResolvedNames Range)
+
 instance (ConstrainSNames ToJSON r a, ToJSON a) => ToJSON (InsertDirectory r a) where
     toJSON stmt = object
         [ "tag" .= String "InsertDirectory"

--- a/src/Database/Sql/Presto/Type.hs
+++ b/src/Database/Sql/Presto/Type.hs
@@ -110,6 +110,9 @@ instance (ConstrainSNames ToJSON r a, ToJSON a) => ToJSON (PrestoStatement r a) 
         , "info" .= info
         ]
 
+typeExample :: ()
+typeExample = const () $ toJSON (undefined :: PrestoStatement ResolvedNames Range)
+
 instance HasTables (PrestoStatement ResolvedNames a) where
     goTables (PrestoStandardSqlStatement s) = goTables s
     goTables (PrestoUnhandledStatement _) = return ()

--- a/src/Database/Sql/Type/Names.hs
+++ b/src/Database/Sql/Type/Names.hs
@@ -470,6 +470,19 @@ instance ToJSON a => ToJSON (TableAlias a) where
         , "ident" .= ident
         ]
 
+instance ToJSON a => ToJSON (RNaturalColumns a) where
+    toJSON (RNaturalColumns cols) = object
+        [ "tag" .= String "RNaturalColumns"
+        , "cols" .= cols
+        ]
+
+instance ToJSON a => ToJSON (RUsingColumn a) where
+    toJSON (RUsingColumn left right) = object
+        [ "tag" .= String "RUsingColumn"
+        , "left" .= left
+        , "right" .= right
+        ]
+
 instance (ToJSON (f (QSchemaName f a)), ToJSON a) => ToJSON (QFunctionName f a) where
     toJSON (QFunctionName info schema function) = object
         [ "tag" .= String "QFunctionName"

--- a/src/Database/Sql/Type/Scope.hs
+++ b/src/Database/Sql/Type/Scope.hs
@@ -41,6 +41,7 @@ import Control.Monad.State
 import Control.Monad.Except
 import Control.Monad.Writer
 
+import           Data.Aeson
 import qualified Data.HashMap.Strict as HMS
 import           Data.HashMap.Strict (HashMap)
 
@@ -314,3 +315,55 @@ instance Arbitrary DatabaseMap where
 instance Arbitrary CatalogMap where
     arbitrary = HMS.fromList <$> arbitrary
     shrink = shrinkHashMap
+
+instance ToJSON a => ToJSON (RTableRef a) where
+    toJSON (RTableRef fqtn _) = object
+        [ "tag" .= String "RTableRef"
+        , "fqtn" .= fqtn
+        ]
+    toJSON (RTableAlias alias) = object
+        [ "tag" .= String "RTableAlias"
+        , "alias" .= alias
+        ]
+
+instance ToJSON a => ToJSON (RTableName a) where
+    toJSON (RTableName fqtn _) = object
+        [ "tag" .= String "RTableName"
+        , "fqtn" .= fqtn
+        ]
+
+instance ToJSON a => ToJSON (RDropTableName a) where
+    toJSON (RDropExistingTableName fqtn _) = object
+        [ "tag" .= String "RDropExistingTableName"
+        , "fqtn" .= fqtn
+        ]
+    toJSON (RDropMissingTableName oqtn) = object
+        [ "tag" .= String "RDropMissingTableName"
+        , "oqtn" .= oqtn
+        ]
+
+instance ToJSON a => ToJSON (RCreateTableName a) where
+    toJSON (RCreateTableName fqtn existence) = object
+        [ "tag" .= String "RCreateTableName"
+        , "fqtn" .= fqtn
+        , "existence" .= existence
+        ]
+
+instance ToJSON a => ToJSON (RCreateSchemaName a) where
+    toJSON (RCreateSchemaName fqsn existence) = object
+        [ "tag" .= String "RCreateSchemaName"
+        , "fqsn" .= fqsn
+        , "existence" .= existence
+        ]
+
+instance ToJSON a => ToJSON (StarColumnNames a) where
+    toJSON (StarColumnNames cols) = object
+        [ "tag" .= String "StarColumnNames"
+        , "cols" .= cols
+        ]
+
+instance ToJSON a => ToJSON (ColumnAliasList a) where
+    toJSON (ColumnAliasList cols) = object
+        [ "tag" .= String "ColumnAliasList"
+        , "cols" .= cols
+        ]

--- a/src/Database/Sql/Type/TableProps.hs
+++ b/src/Database/Sql/Type/TableProps.hs
@@ -76,6 +76,10 @@ instance ToJSON a => ToJSON (Externality a) where
 
     toJSON Internal = object ["tag" .= String "Internal"]
 
+instance ToJSON Existence where
+    toJSON Exists = object ["tag" .= String "Exists"]
+    toJSON DoesNotExist = object ["tag" .= String "DoesNotExist"]
+
 instance ToJSON TableType where
     toJSON Table = object ["tag" .= String "Table"]
     toJSON View = object ["tag" .= String "View"]
@@ -100,6 +104,17 @@ instance FromJSON a => FromJSON (Externality a) where
 
     parseJSON v = fail $ unwords
         [ "don't know how to parse as Externality:"
+        , show v
+        ]
+
+instance FromJSON Existence where
+    parseJSON (Object o) = o .: "tag" >>= \case
+        String "Exists" -> pure Exists
+        String "DoesNotExist" -> pure DoesNotExist
+        _ -> fail "unrecognized tag on Existence object"
+
+    parseJSON v = fail $ unwords
+        [ "don't know how to parse as Existence:"
         , show v
         ]
 

--- a/src/Database/Sql/Vertica/Type.hs
+++ b/src/Database/Sql/Vertica/Type.hs
@@ -549,6 +549,9 @@ instance (ConstrainSNames ToJSON r a, ToJSON a) => ToJSON (VerticaStatement r a)
         , "info" .= info
         ]
 
+typeExample :: ()
+typeExample = const () $ toJSON (undefined :: VerticaStatement ResolvedNames Range)
+
 instance (ConstrainSNames ToJSON r a, ToJSON a) => ToJSON (CreateProjection r a) where
     toJSON CreateProjection{..} = JSON.object
         [ "tag" .= JSON.String "CreateProjection"


### PR DESCRIPTION
This will permit the implementation (externally) of a service endpoint
"parseAndResolve" which returns a query's resolved AST.

There were a few toJSON instances that had to be implemented. In the
future, we will catch missing toJSON-instances at compile time, thanks
to the added explicit type examples on Vertica/Hive/Presto statements.