### PR TITLE
[ghc] upgrade to GHC 8 and update base package

### DIFF
--- a/demo/queryparser-demo.cabal
+++ b/demo/queryparser-demo.cabal
@@ -1,21 +1,21 @@
 name:                queryparser-demo
 version:             0.1.0.0
--- synopsis:            
--- description:         
+-- synopsis:
+-- description:
 license:             MIT
 license-file:        LICENSE
 author:              Heli Wang, David Thomas, Matt Halverson
 maintainer:          heli@uber.com
--- copyright:           
+-- copyright:
 category:            Database
 build-type:          Simple
 cabal-version:       >=1.10
 
 library
   exposed-modules:     Demo
-  -- other-modules:       
-  -- other-extensions:    
-  build-depends:       base >=4.8 && <4.9
+  -- other-modules:
+  -- other-extensions:
+  build-depends:       base >=4.10 && <4.11
                      , queryparser
                      , queryparser-vertica
                      , unordered-containers >=0.2 && <0.3

--- a/dialects/hive/queryparser-hive.cabal
+++ b/dialects/hive/queryparser-hive.cabal
@@ -62,7 +62,7 @@ library
                      , Database.Sql.Hive.Parser.Internal
 
   -- Modules included in this library but not exported.
-  -- other-modules:     
+  -- other-modules:
 
   default-extensions:  OverloadedStrings
                      , LambdaCase
@@ -72,7 +72,7 @@ library
                      , FlexibleInstances
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.8 && <4.9
+  build-depends:       base >=4.10 && <4.11
                      , text >=1.2 && <1.3
                      , bytestring
                      , queryparser

--- a/dialects/presto/queryparser-presto.cabal
+++ b/dialects/presto/queryparser-presto.cabal
@@ -62,7 +62,7 @@ library
                      , Database.Sql.Presto.Parser.Internal
 
   -- Modules included in this library but not exported.
-  -- other-modules:     
+  -- other-modules:
 
   default-extensions:  OverloadedStrings
                      , LambdaCase
@@ -72,7 +72,7 @@ library
                      , FlexibleInstances
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.8 && <4.9
+  build-depends:       base >=4.10 && <4.11
                      , text >=1.2 && <1.3
                      , bytestring
                      , queryparser

--- a/dialects/vertica/queryparser-vertica.cabal
+++ b/dialects/vertica/queryparser-vertica.cabal
@@ -65,7 +65,7 @@ library
                      , Database.Sql.Vertica.Parser.Shared
 
   -- Modules included in this library but not exported.
-  -- other-modules:     
+  -- other-modules:
 
   default-extensions:  OverloadedStrings
                      , LambdaCase
@@ -75,7 +75,7 @@ library
                      , FlexibleInstances
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.8 && <4.9
+  build-depends:       base >=4.10 && <4.11
                      , text >=1.2 && <1.3
                      , bytestring
                      , queryparser

--- a/misc/predicate-class/predicate-class.cabal
+++ b/misc/predicate-class/predicate-class.cabal
@@ -1,20 +1,20 @@
 name:                predicate-class
 version:             0.1.0.0
--- synopsis:            
--- description:         
+-- synopsis:
+-- description:
 license:             MIT
 license-file:        LICENSE
 author:              David Thomas
 maintainer:          heli@uber.com
--- copyright:           
+-- copyright:
 category:            Data
 build-type:          Simple
 cabal-version:       >=1.10
 
 library
   exposed-modules:     Data.Predicate.Class
-  -- other-modules:       
-  -- other-extensions:    
-  build-depends:       base >=4.8 && <4.9
+  -- other-modules:
+  -- other-extensions:
+  build-depends:       base >=4.10 && <4.11
   hs-source-dirs:      src
   default-language:    Haskell98

--- a/queryparser.cabal
+++ b/queryparser.cabal
@@ -89,7 +89,7 @@ library
                      , FlexibleInstances
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.8 && <4.9
+  build-depends:       base >=4.10 && <4.11
                      , text >=1.2 && <1.3
                      , bytestring
                      , containers
@@ -120,7 +120,7 @@ library
 benchmark queryparser-bench
   type:                exitcode-stdio-1.0
   main-is:             Bench.hs
-  build-depends:       base >=4.8 && <4.9
+  build-depends:       base >=4.10 && <4.11
                      , queryparser
                      , criterion
                      , text

--- a/src/Data/Functor/Identity/Orphans.hs
+++ b/src/Data/Functor/Identity/Orphans.hs
@@ -21,11 +21,3 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Data.Functor.Identity.Orphans where
-
-import Data.Functor.Identity
-
-import Test.QuickCheck
-
-instance Arbitrary a => Arbitrary (Identity a) where
-    arbitrary = Identity <$> arbitrary
-    shrink (Identity x) = Identity <$> shrink x

--- a/src/Database/Sql/Type/Names.hs
+++ b/src/Database/Sql/Type/Names.hs
@@ -484,11 +484,11 @@ instance ToJSON a => ToJSON (RUsingColumn a) where
         ]
 
 instance (ToJSON (f (QSchemaName f a)), ToJSON a) => ToJSON (QFunctionName f a) where
-    toJSON (QFunctionName info schema function) = object
+    toJSON (QFunctionName info schema fn) = object
         [ "tag" .= String "QFunctionName"
         , "info" .= info
         , "schema" .= schema
-        , "function" .= function
+        , "function" .= fn
         ]
 
 

--- a/src/Database/Sql/Type/Query.hs
+++ b/src/Database/Sql/Type/Query.hs
@@ -897,10 +897,10 @@ instance ConstrainSNames ToJSON r a => ToJSON (Expr r a) where
         , "query" .= query
         ]
 
-    toJSON (FunctionExpr info function distinct args params filter' over) = object
+    toJSON (FunctionExpr info fn distinct args params filter' over) = object
         [ "tag" .= String "FunctionExpr"
         , "info" .= info
-        , "function" .= function
+        , "function" .= fn
         , "distinct" .= distinct
         , "args" .= args
         , "params" .= params
@@ -1401,7 +1401,7 @@ instance FromJSON a => FromJSON (Constant a) where
             info <- o .: "info"
             value <- TL.encodeUtf8 <$> o .: "value"
                 <|> BL.pack <$> o .: "value"
-                <|> fail "expected string or array for StringConstant value" 
+                <|> fail "expected string or array for StringConstant value"
             pure $ StringConstant info value
 
         String "NumericConstant" ->

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-6.29
+resolver: lts-10.4
 
 # Local packages, usually specified by relative directory name
 packages:
@@ -17,7 +17,10 @@ docker:
     enable: true
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: ['test-framework-quickcheck-0.3.0']
+extra-deps: [ 'test-framework-quickcheck-0.3.0'
+            , 'file-location-0.4.9.1'
+            , 'fixed-list-0.1.6'
+            ]
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/test/queryparser-test.cabal
+++ b/test/queryparser-test.cabal
@@ -64,7 +64,7 @@ library
                      , Database.Sql.Util.Catalog.Test
                      , Database.Sql.Util.Columns.Test
                      , Test.HUnit.Ticket
-  build-depends:       base >=4.8 && <4.9
+  build-depends:       base >=4.10 && <4.11
                      , queryparser
                      , queryparser-vertica
                      , queryparser-hive
@@ -79,7 +79,7 @@ library
                      , unordered-containers
                      , file-location
                      , hpc
-                     , HUnit >= 1.2 && < 1.4
+                     , HUnit >= 1.2
                      , template-haskell
                      , test-framework
                      , test-framework-hunit
@@ -117,12 +117,13 @@ test-suite queryparser-test-suite
                      , Database.Sql.Util.Lineage.ColumnPlus.Test
                      , Database.Sql.Util.Schema.Test
                      , Database.Sql.Util.Scope.Test
+                     , Database.Sql.Util.Tables.Test
                      , Database.Sql.Util.Test
                      , Database.Sql.Util.Catalog
                      , Database.Sql.Util.Catalog.Test
                      , Database.Sql.Util.Columns.Test
                      , Test.HUnit.Ticket
-  build-depends:       base >=4.8 && <4.9
+  build-depends:       base >=4.10 && <4.11
                      , queryparser-test
                      , queryparser
                      , queryparser-vertica
@@ -138,7 +139,7 @@ test-suite queryparser-test-suite
                      , unordered-containers
                      , file-location
                      , hpc
-                     , HUnit >= 1.2 && < 1.4
+                     , HUnit >= 1.2
                      , template-haskell
                      , test-framework
                      , test-framework-hunit


### PR DESCRIPTION
Upgrade to recent stack lts 10.4: https://www.stackage.org/lts-10.4
* GHC 8.2.2
* base 4.10.1.0