### PR TITLE
support stackage lts-7.19 (while preserving support for newer)

### DIFF
--- a/compat/Test/QuickCheck.hs
+++ b/compat/Test/QuickCheck.hs
@@ -19,5 +19,17 @@
 -- THE SOFTWARE.
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE PackageImports #-}
+{-# LANGUAGE CPP #-}
 
-module Data.Functor.Identity.Orphans where
+module Test.QuickCheck (module X) where
+
+import "QuickCheck" Test.QuickCheck as X
+
+#if !MIN_VERSION_QuickCheck(2,9,0)
+import Data.Functor.Identity
+
+instance Arbitrary a => Arbitrary (Identity a) where
+    arbitrary = Identity <$> arbitrary
+    shrink (Identity x) = Identity <$> shrink x
+#endif

--- a/demo/queryparser-demo.cabal
+++ b/demo/queryparser-demo.cabal
@@ -15,7 +15,7 @@ library
   exposed-modules:     Demo
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.10 && <4.11
+  build-depends:       base >=4.9 && <4.11
                      , queryparser
                      , queryparser-vertica
                      , unordered-containers >=0.2 && <0.3

--- a/dialects/hive/queryparser-hive.cabal
+++ b/dialects/hive/queryparser-hive.cabal
@@ -72,7 +72,7 @@ library
                      , FlexibleInstances
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.10 && <4.11
+  build-depends:       base >=4.9 && <4.11
                      , text >=1.2 && <1.3
                      , bytestring
                      , queryparser
@@ -94,7 +94,7 @@ library
   hs-source-dirs:      src
 
 
-  ghc-options:         -Wall
+  ghc-options:         -Wall -Wno-redundant-constraints
 
   if flag(development)
     ghc-options:       -Werror

--- a/dialects/presto/queryparser-presto.cabal
+++ b/dialects/presto/queryparser-presto.cabal
@@ -72,7 +72,7 @@ library
                      , FlexibleInstances
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.10 && <4.11
+  build-depends:       base >=4.9 && <4.11
                      , text >=1.2 && <1.3
                      , bytestring
                      , queryparser

--- a/dialects/vertica/queryparser-vertica.cabal
+++ b/dialects/vertica/queryparser-vertica.cabal
@@ -75,7 +75,7 @@ library
                      , FlexibleInstances
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.10 && <4.11
+  build-depends:       base >=4.9 && <4.11
                      , text >=1.2 && <1.3
                      , bytestring
                      , queryparser

--- a/misc/predicate-class/predicate-class.cabal
+++ b/misc/predicate-class/predicate-class.cabal
@@ -15,6 +15,6 @@ library
   exposed-modules:     Data.Predicate.Class
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.10 && <4.11
+  build-depends:       base >=4.9 && <4.11
   hs-source-dirs:      src
   default-language:    Haskell98

--- a/queryparser.cabal
+++ b/queryparser.cabal
@@ -79,7 +79,7 @@ library
 
   -- Modules included in this library but not exported.
   other-modules:       Data.Maybe.More
-                     , Data.Functor.Identity.Orphans
+                     , Test.QuickCheck
 
   default-extensions:  OverloadedStrings
                      , LambdaCase
@@ -89,7 +89,7 @@ library
                      , FlexibleInstances
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.10 && <4.11
+  build-depends:       base >=4.9 && <4.11
                      , text >=1.2 && <1.3
                      , bytestring
                      , containers
@@ -106,10 +106,10 @@ library
                      , predicate-class
 
   -- Directories containing source files.
-  hs-source-dirs:      src
+  hs-source-dirs:      src, compat
 
 
-  ghc-options:         -Wall
+  ghc-options:         -Wall -Wno-redundant-constraints
 
   if flag(development)
     ghc-options:       -Werror
@@ -120,7 +120,7 @@ library
 benchmark queryparser-bench
   type:                exitcode-stdio-1.0
   main-is:             Bench.hs
-  build-depends:       base >=4.10 && <4.11
+  build-depends:       base >=4.9 && <4.11
                      , queryparser
                      , criterion
                      , text

--- a/src/Database/Sql/Type/Names.hs
+++ b/src/Database/Sql/Type/Names.hs
@@ -41,7 +41,6 @@ import Data.Aeson
 import Data.Semigroup
 import Data.String
 import Data.Functor.Identity
-import Data.Functor.Identity.Orphans ()
 import Data.Data (Data, Typeable)
 
 import qualified Data.Map as M

--- a/test/queryparser-test.cabal
+++ b/test/queryparser-test.cabal
@@ -64,7 +64,7 @@ library
                      , Database.Sql.Util.Catalog.Test
                      , Database.Sql.Util.Columns.Test
                      , Test.HUnit.Ticket
-  build-depends:       base >=4.10 && <4.11
+  build-depends:       base >=4.9 && <4.11
                      , queryparser
                      , queryparser-vertica
                      , queryparser-hive
@@ -123,7 +123,7 @@ test-suite queryparser-test-suite
                      , Database.Sql.Util.Catalog.Test
                      , Database.Sql.Util.Columns.Test
                      , Test.HUnit.Ticket
-  build-depends:       base >=4.10 && <4.11
+  build-depends:       base >=4.9 && <4.11
                      , queryparser-test
                      , queryparser
                      , queryparser-vertica


### PR DESCRIPTION
lts-7.19 is the newest that currently works with GHCJS out of the box