### PR TITLE
 Extending support of `SET` statements

### DIFF
--- a/dialects/hive/src/Database/Sql/Hive/Parser.hs
+++ b/dialects/hive/src/Database/Sql/Hive/Parser.hs
@@ -467,16 +467,13 @@ setP :: Parser (SetProperty Range)
 setP = do
     s <- Tok.setP
     option (PrintProperties s "") $ choice $
-      [ do
-        _ <- Tok.minusP >> Tok.keywordP "v"
-        pure $ PrintProperties s "-v"
-
-        , do
+      [ Tok.minusP >> Tok.keywordP "v" >> pure (PrintProperties s "-v")
+      , do
         (name, _)  <- Tok.propertyNameP
         _ <- Tok.equalP
         (setConfigValue, e) <- Tok.propertyValuePartP
         let details = SetPropertyDetails (s <> e) name setConfigValue
-        pure $ SetProperty details
+        pure (SetProperty details)
       ]
 
 reloadFunctionP :: Parser Range

--- a/dialects/hive/src/Database/Sql/Hive/Parser/Token.hs
+++ b/dialects/hive/src/Database/Sql/Hive/Parser/Token.hs
@@ -178,7 +178,7 @@ propertyNameP = textUntilP ["=", ";"]
 --  returns parsed text.
 textUntilP :: [Text] -> Parser (Text, Range)
 textUntilP x = do
-    res <- P.many $ anyTokenExceptX
+    res <- P.many anyTokenExceptX
     let name = Data.Text.Lazy.concat $ fst <$> res
         s = snd $ head res
         e = snd $ last res

--- a/test/Database/Sql/Hive/Parser/Test.hs
+++ b/test/Database/Sql/Hive/Parser/Test.hs
@@ -425,6 +425,7 @@ testParser_hiveSuite = test
       , "SET hive.exec.parallel = true;"
       , "SET mapred.output.compression.codec=org.apache.hadoop.io.compress.SnappyCodec;"
       , "SET mapreduce.job.queuename=foo-bar-baz;"
+      , "SET x*x=1*5;"
       , "SET foo-bar-baz=foo-bar-baz;"
       , "SET;"
       , "SET -v;"


### PR DESCRIPTION
This change extends the support of Hive `SET` statements. Original parser was not able to support some of the more exotic cases in Hive. For example the following is legal in Hive: `SET x  x=x  x;`.

The change adds a rudimentary parsing test for the exotic case.