### PR TITLE
Fixing single variable printing parsing

### DIFF
--- a/dialects/hive/src/Database/Sql/Hive/Parser.hs
+++ b/dialects/hive/src/Database/Sql/Hive/Parser.hs
@@ -469,11 +469,15 @@ setP = do
     option (PrintProperties s "") $ choice $
       [ Tok.minusP >> Tok.keywordP "v" >> pure (PrintProperties s "-v")
       , do
-        (name, _)  <- Tok.propertyNameP
-        _ <- Tok.equalP
-        (setConfigValue, e) <- Tok.propertyValuePartP
-        let details = SetPropertyDetails (s <> e) name setConfigValue
-        pure (SetProperty details)
+        (name, pe)  <- Tok.propertyNameP
+        choice $
+          [ do
+              _ <- Tok.equalP
+              (setConfigValue, e) <- Tok.propertyValuePartP
+              let details = SetPropertyDetails (s <> e) name setConfigValue
+              pure (SetProperty details)
+          , pure (PrintProperties (s <> pe) name)
+          ]
       ]
 
 reloadFunctionP :: Parser Range

--- a/test/Database/Sql/Hive/Parser/Test.hs
+++ b/test/Database/Sql/Hive/Parser/Test.hs
@@ -428,6 +428,7 @@ testParser_hiveSuite = test
       , "SET mapreduce.job.queuename=foo-bar-baz;"
       , "SET x*x=1*5;"
       , "SET foo-bar-baz=foo-bar-baz;"
+      , "SET mapreduce.job.queuename;"
       , "SET;"
       , "SET -v;"
       , TL.unlines


### PR DESCRIPTION
This fixes the parsing of a single variable statement: `SET mapreduce.job.queuename;`.