### PR TITLE
fix Vertica "CREATE VIEW" statement parsing

### DIFF
--- a/dialects/vertica/src/Database/Sql/Vertica/Parser.hs
+++ b/dialects/vertica/src/Database/Sql/Vertica/Parser.hs
@@ -579,7 +579,7 @@ createViewP = do
         Temporary _ -> pure ()
 
     _ <- Tok.asP
-    createViewQuery <- querySelectP
+    createViewQuery <- queryP
 
     let createViewInfo = s <> getInfo createViewQuery
     pure CreateView{..}

--- a/test/Database/Sql/Vertica/Parser/Test.hs
+++ b/test/Database/Sql/Vertica/Parser/Test.hs
@@ -398,6 +398,18 @@ testParser = test
         , "SELECT date_trunc('week', foo.at) FROM foo;"
         , "SELECT foo::TIME FROM bar;"
         , "CREATE VIEW foo.bar AS SELECT * FROM foo.baz;"
+        , TL.unlines
+          [ "CREATE VIEW foo.bar_view AS"
+          , "    SELECT"
+          , "        a0 AS a,"
+          , "        b0 AS b"
+          , "    FROM foo.bar0"
+          , "UNION"
+          , "    SELECT"
+          , "        a1 AS a,"
+          , "        b1 AS b"
+          , "    FROM foo.bar1;"
+          ]
         , "CREATE LOCAL TEMPORARY VIEW bar AS SELECT * FROM baz;"
         , TL.unlines
           [ "CREATE OR REPLACE VIEW foo.bar (a, b) "


### PR DESCRIPTION
Vertica [CREATE VIEW](https://www.vertica.com/docs/9.2.x/HTML/Content/Authoring/SQLReferenceManual/Statements/CREATEVIEW.htm) statements can contain more complex `SELECT` [queries](https://www.vertica.com/docs/9.2.x/HTML/Content/Authoring/SQLReferenceManual/Statements/SELECT/SELECT.htm) (including `UNION`, `ORDER BY` and other clauses). Since all of the currently existing value constructors of [Query](https://github.com/uber/queryparser/blob/8b8eae8f7a0d2370227a2659fe368afe5cf91431/src/Database/Sql/Type/Query.hs#L53) are supported by Vertica in `SELECT` and therefore in `CREATE VIEW`, [queryP](https://github.com/uber/queryparser/blob/33673f613ea20afee5bbcd71be89049740ad29e8/dialects/vertica/src/Database/Sql/Vertica/Parser.hs#L257) can be used in parsing `CREATE VIEW` statements.

Related issue - #48