### PR TITLE
Parse CURRENT_TIMESTAMP(1) in vertica

### DIFF
--- a/dialects/vertica/src/Database/Sql/Vertica/Token.hs
+++ b/dialects/vertica/src/Database/Sql/Vertica/Token.hs
@@ -55,7 +55,7 @@ wordInfo word = maybe (WordInfo True True True True) id $ M.lookup word $ M.from
     , ("current_database",     WordInfo False False False True)
     , ("current_date",         WordInfo False False False True)
     , ("current_schema",       WordInfo False False False True)
-    , ("current_timestamp",    WordInfo False False False False)
+    , ("current_timestamp",    WordInfo False False False True)
     , ("current_time",         WordInfo False False False False)
     , ("current_user",         WordInfo False False False True)
     , ("desc",                 WordInfo False False False False)

--- a/test/Database/Sql/Vertica/Parser/Test.hs
+++ b/test/Database/Sql/Vertica/Parser/Test.hs
@@ -398,6 +398,7 @@ testParser = test
         , "SELECT cast('1 minutes' AS INTERVAL MINUTE);"
         , "SELECT date_trunc('week', foo.at) FROM foo;"
         , "SELECT foo::TIME FROM bar;"
+        , "SELECT CURRENT_TIMESTAMP(1) AS time;"
         , "CREATE VIEW foo.bar AS SELECT * FROM foo.baz;"
         , TL.unlines
           [ "CREATE VIEW foo.bar_view AS"


### PR DESCRIPTION
In Vertica, `CURRENT_TIMESTAMP` is a function that accepts one argument, as per the [docs](https://www.vertica.com/docs/9.2.x/HTML/Content/Authoring/SQLReferenceManual/Functions/Date-Time/CURRENT_TIMESTAMP.htm). The docs provide this example query demonstrating its usage:

```
SELECT CURRENT_TIMESTAMP(1) AS time;
```

Currently, queryparser fails to parse this query. This PR fixes this behaviour.

I've added this example to the tests, but I wasn't sure of where the best place to put it was. Please let me know if it is best placed somewhere else :)